### PR TITLE
Add phpunit to composer.json, Make changes for using phpunit 5.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/*
 build/*
 .idea
 phpunit.xml
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
-{   
+{
     "name": "marlon-be/marlon-sips",
+    "require-dev": {
+        "phpunit/phpunit": "5.4.*"
+    },
     "autoload": {
         "psr-0": { "Sips": "lib/" }
     }

--- a/tests/Sips/Tests/PaymentRequestTest.php
+++ b/tests/Sips/Tests/PaymentRequestTest.php
@@ -205,7 +205,7 @@ class PaymentRequestTest extends \TestCase
      */
     public function GetShaSign()
     {
-        $shaComposer = $this->getMock('Sips\ShaComposer\ShaComposer');
+        $shaComposer = $this->createMock('Sips\ShaComposer\ShaComposer');
         $paymentRequest = PaymentRequest::createFromArray($shaComposer, array(
             'merchantId' => '002001000000001',
             'normalReturnUrl' => 'http://www.normalreturnurl.com',

--- a/tests/Sips/Tests/PaymentResponseTest.php
+++ b/tests/Sips/Tests/PaymentResponseTest.php
@@ -16,7 +16,7 @@ class PaymentResponseTest extends \TestCase
         $aRequest = $this->provideRequest();
         
         $paymentResponse = new PaymentResponse($aRequest);
-        $shaComposer = $this->getMock('Sips\ShaComposer\ShaComposer');
+        $shaComposer = $this->createMock('Sips\ShaComposer\ShaComposer');
 
         $shaComposer->expects($this->once())
                     ->method('compose')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 use Sips\Tests\ShaComposer\FakeShaComposer;
 use Sips\PaymentRequest;
+use PHPUnit_Framework_TestCase;
 
-require_once 'PHPUnit/Framework/TestCase.php';
 require_once __DIR__.'/Sips/Tests/ShaComposer/FakeShaComposer.php';
 
 abstract class TestCase extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
This adds phpunit to composer's require-dev, so people don't need to have phpunit installed globally, but they can do ``composer install`` and run phpunit like this: ``vendor/bin/phpunit tests`` from the root of the directory.

I also made some changes to phpunit 5 is supported.