### PR TITLE
Update request URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Requirements:
 
 The SIPS platform can be reached through the following URL's:
 
-- SIMU: https://payment-webinit.simu.sips-atos.com/paymentInit
-- TEST: https://payment-webinit.test.sips-atos.com/paymentInit
-- PRODUCTION: https://payment-webinit.sips-atos.com/paymentInit
+- SIMU: https://payment-webinit.simu.sips-services.com/paymentInit
+- TEST: https://payment-webinit.test.sips-services.com/paymentInit
+- PRODUCTION: https://payment-webinit.sips-services.com/paymentInit
 
 ## Overview ##
 

--- a/lib/Sips/PaymentRequest.php
+++ b/lib/Sips/PaymentRequest.php
@@ -9,9 +9,9 @@ use Sips\Normalizer;
 
 class PaymentRequest
 {
-    const SIMU = "https://payment-webinit.simu.sips-atos.com/paymentInit";
-    const TEST = "https://payment-webinit.test.sips-atos.com/paymentInit";
-    const PRODUCTION = "https://payment-webinit.sips-atos.com/paymentInit";
+    const SIMU = "https://payment-webinit.simu.sips-services.com/paymentInit";
+    const TEST = "https://payment-webinit.test.sips-services.com/paymentInit";
+    const PRODUCTION = "https://payment-webinit.sips-services.com/paymentInit";
 
     private $brandsmap = array(
         'ACCEPTGIRO' => 'CREDIT_TRANSFER',


### PR DESCRIPTION
⚠️ As of 30/06/2021 the sips-atos.com urls will stop working. they have been replaced by sips-services.com urls. Make sure to update to version 1.0.7 or higher to avoid problems.

See https://github.com/marlon-be/marlon-sips/pull/6